### PR TITLE
symlink Debian to Ubuntu

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,0 +1,1 @@
+Ubuntu.yml

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,1 @@
+Ubuntu.yml


### PR DESCRIPTION
If we symlink the Ubuntu.yml to Debian.yml, it works for Ubuntu and Debian
