### PR TITLE
Add variable and tasks to revoke certificates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,20 @@ This role requires Ansible 1.9 or higher.
 Role Variables
 --------------
 
-| Name                  | Default                | Description                                  |
-|:----------------------|:-----------------------|:---------------------------------------------|
-| easy_rsa_ca_expire    | 3650                   | Number of days that CA is valid for          |
-| easy_rsa_clients      | []                     | List of client certificates/keys to generate |
-| easy_rsa_key_city     | "SanFrancisco"         | City                                         |
-| easy_rsa_key_country  | "US"                   | Country                                      |
-| easy_rsa_key_email    | "me@myhost.mydomain"   | Email address                                |
-| easy_rsa_key_expire   | 3650                   | Number of days that key is valid for         |
-| easy_rsa_key_name     | "EasyRSA"              | Name of server key                           |
-| easy_rsa_key_org      | "Fort-Funston"         | Organization                                 |
-| easy_rsa_key_ou       | "MyOrganizationalUnit" | Organizational Unit                          |
-| easy_rsa_key_province | "CA"                   | Province                                     |
-| easy_rsa_key_size     | 2048                   | Diffie-Hellman key size                      |
+| Name                    | Default                | Description                                  |
+|:------------------------|:-----------------------|:---------------------------------------------|
+| easy_rsa_ca_expire      | 3650                   | Number of days that CA is valid for          |
+| easy_rsa_clients        | []                     | List of client certificates/keys to generate |
+| easy_rsa_clients_revoke | []                     | List of client certificates/keys to revoke |
+| easy_rsa_key_city       | "SanFrancisco"         | City                                         |
+| easy_rsa_key_country    | "US"                   | Country                                      |
+| easy_rsa_key_email      | "me@myhost.mydomain"   | Email address                                |
+| easy_rsa_key_expire     | 3650                   | Number of days that key is valid for         |
+| easy_rsa_key_name       | "EasyRSA"              | Name of server key                           |
+| easy_rsa_key_org        | "Fort-Funston"         | Organization                                 |
+| easy_rsa_key_ou         | "MyOrganizationalUnit" | Organizational Unit                          |
+| easy_rsa_key_province   | "CA"                   | Province                                     |
+| easy_rsa_key_size       | 2048                   | Diffie-Hellman key size                      |
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 
 easy_rsa_ca_expire: 3650
 easy_rsa_clients: []
+easy_rsa_clients_revoke: []
 easy_rsa_key_city: "SanFrancisco"
 easy_rsa_key_country: "US"
 easy_rsa_key_email: "me@myhost.mydomain"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,6 +96,33 @@
   tags:
     - easy_rsa
 
+- name: Check list of clients vs revokes
+  fail: msg="There are clients set to create and revoke at the same time. That's not possible."
+  when: "{{ (easy_rsa_clients | intersect(easy_rsa_clients_revoke) | length) > 0 }}"
+
+- name: Check certificate index
+  become: yes
+  command: awk '$0 ~ /\/CN={{ item }}\// {print $1; exit}' "{{ easy_rsa_key_dir }}/index.txt"
+  register: certificate_index
+  with_items: "{{ easy_rsa_clients_revoke }}"
+  always_run: true
+
+- name: Revoke client certificates
+  become: yes
+  shell: ". ./vars; ./revoke-full {{ item }}"
+  args:
+    chdir: "{{ easy_rsa_ca_dir }}"
+  with_items:
+    - "{{ easy_rsa_clients_revoke }}"
+  when: (certificate_index.results | selectattr('item', 'equalto', item) | map(attribute='stdout') | list | first | default("R")) == "V"
+  register: revoke_return
+  failed_when: revoke_return.rc > 0 and revoke_return.rc != 2
+
+- name: Remove revoke client *.key file
+  become: yes
+  file: path="{{ easy_rsa_key_dir }}/{{ item}}.key" state=absent
+  with_items: "{{ revoke_return.results | selectattr('changed') | map(attribute='item') | list }}"
+
 - name: Generate client certificates and keys
   become: yes
   shell: ". ./vars; ./pkitool {{ item }} >/dev/null"
@@ -104,5 +131,6 @@
     creates: "{{ easy_rsa_key_dir }}/{{ item }}.key"
   with_items:
     - "{{ easy_rsa_clients }}"
+  when: (certificate_index.results | selectattr('item', 'equalto', item) | map(attribute='stdout') | list | first | default("R")) != "V"
   tags:
     - easy_rsa


### PR DESCRIPTION
Added `easy_rsa_clients_revoke` variable, a list like `easy_rsa_clients`. And it works like `easy_rsa_clients` but instead of generate certificates and private keys, it deletes revokes and then deletes the private key file.